### PR TITLE
Fix duplicated map keys (cannot compile on Elixir 1.10)

### DIFF
--- a/lib/sitemap/adapter.ex
+++ b/lib/sitemap/adapter.ex
@@ -47,11 +47,11 @@ defmodule Sitemap.Adapter do
     end
   end
 
-  def pre_work(%{host: <<host::binary()>>, public_path: <<public::binary()>>, public_path: path, name: name, compress: true}) do
+  def pre_work(%{host: <<host::binary()>>, public_path: <<public::binary()>> = path, name: name, compress: true}) do
     host = URI.parse(host)
     Config.update(%{host: host, public_path: host |> URI.merge(public) |> URI.to_string(), index_path: Path.join(path, "#{name}.xml.gz")})
   end
-  def pre_work(%{host: <<host::binary()>>, public_path: <<public::binary()>>, public_path: path, name: name, compress: false}) do
+  def pre_work(%{host: <<host::binary()>>, public_path: <<public::binary()>> = path, name: name, compress: false}) do
     host = URI.parse(host)
     Config.update(%{host: host, public_path: host |> URI.merge(public) |> URI.to_string(), index_path: Path.join(path, "#{name}.xml")})
   end

--- a/lib/sitemap/adapter/s3.ex
+++ b/lib/sitemap/adapter/s3.ex
@@ -4,11 +4,11 @@ if Code.ensure_compiled?(ExAws.S3) do
     use Sitemap.Adapter
     alias Sitemap.Config
 
-    def pre_work(%{host: <<host::binary()>>, public_path: <<public::binary()>>, files_path: <<path::binary()>>, bucket: bucket, public_path: path, name: name, compress: true} = config) when byte_size(bucket) > 0 do
+    def pre_work(%{host: <<host::binary()>>, public_path: <<public::binary()>> = path, files_path: <<path::binary()>>, bucket: bucket, name: name, compress: true} = config) when byte_size(bucket) > 0 do
       host = URI.parse(host)
       Config.update(%{config | host: host, public_path: host |> URI.merge(public) |> URI.to_string(), files_path: Path.join(tmp_dir(), path), index_path: Path.join(path, "#{name}.xml.gz")})
     end
-    def pre_work(%{host: <<host::binary()>>, public_path: <<public::binary()>>, files_path: <<path::binary()>>, bucket: bucket, public_path: path, name: name, compress: false} = config) when byte_size(bucket) > 0 do
+    def pre_work(%{host: <<host::binary()>>, public_path: <<public::binary()>> = path, files_path: <<path::binary()>>, bucket: bucket, name: name, compress: false} = config) when byte_size(bucket) > 0 do
       host = URI.parse(host)
       Config.update(%{config | host: host, public_path: host |> URI.merge(public) |> URI.to_string(), files_path: Path.join(tmp_dir(), path), index_path: Path.join(path, "#{name}.xml")})
     end


### PR DESCRIPTION
Remove duplicated keys that are failing to compile in Elixir 1.10 otp-22.